### PR TITLE
Use XDocument

### DIFF
--- a/CSharp/ProductExport/XmlExporter.cs
+++ b/CSharp/ProductExport/XmlExporter.cs
@@ -7,56 +7,47 @@ namespace ProductExport
 {
     public class XmlExporter
     {
-        public static string ExportFull(List<Order> orders)
+        public static XDocument ExportFull(List<Order> orders)
         {
             var root = new XElement("orders");
-            var xml = new StringBuilder();
-            xml.Append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-            xml.Append("<orders>");
             foreach (var order in orders)
             {
-                var orderElement = new XElement("order",new XAttribute("id",order.Id));
+                var orderElement = new XElement(
+                    "order",
+                    new XAttribute("id", order.Id));
                 root.Add(orderElement);
-                xml.Append("<order");
-                xml.Append(" id='");
-                xml.Append(order.Id);
-                xml.Append("'>");
                 foreach (var product in order.Products)
                 {
-                    var productElement = new XElement("product",new XAttribute("id",product.Id));
-                    xml.Append("<product");
-                    xml.Append(" id='");
-                    xml.Append(product.Id);
-                    xml.Append("'");
+                    var productElement = new XElement(
+                        "product",
+                        new XAttribute("id", product.Id)
+                        );
                     if (product.IsEvent())
                     {
-                        productElement.Add(new XAttribute("stylist", StylistFor(product)));
-                        xml.Append(" stylist='");
-                        xml.Append(StylistFor(product));
-                        xml.Append("'");
+                        productElement.Add(
+                            new XAttribute("stylist", StylistFor(product)));
                     }
 
                     if (product.Weight > 0)
                     {
-                        productElement.Add(new XAttribute("weight", product.Weight));
+                        productElement.Add(
+                            new XAttribute("weight", product.Weight));
                     }
 
-                    xml.Append("<price");
-                    xml.Append(" currency='");
-                    xml.Append(product.Price.CurrencyCode);
-                    xml.Append("'>");
-                    xml.Append(product.Price.Amount);
-                    xml.Append("</price>");
-                    xml.Append(product.Name);
-                    xml.Append("</product>");
-                }
+                    var price = product.Price;
+                    productElement.Add(
+                        new XElement(
+                            "price",
+                            new XAttribute("currency", price.CurrencyCode),
+                            price.Amount));
 
-                xml.Append("</order>");
+                    productElement.Add(product.Name);
+
+                    orderElement.Add(productElement);
+                }
             }
 
-            xml.Append("</orders>");
-            var document = new XDocument(root);
-            return XmlFormatter.PrettyPrint(xml.ToString());
+            return new XDocument(root);
         }
 
         public static string ExportTaxDetails(List<Order> orders)

--- a/CSharp/ProductExport/XmlExporter.cs
+++ b/CSharp/ProductExport/XmlExporter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Xml.Linq;
 
 namespace ProductExport
 {
@@ -8,23 +9,28 @@ namespace ProductExport
     {
         public static string ExportFull(List<Order> orders)
         {
+            var root = new XElement("orders");
             var xml = new StringBuilder();
             xml.Append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
             xml.Append("<orders>");
             foreach (var order in orders)
             {
+                var orderElement = new XElement("order",new XAttribute("id",order.Id));
+                root.Add(orderElement);
                 xml.Append("<order");
                 xml.Append(" id='");
                 xml.Append(order.Id);
                 xml.Append("'>");
                 foreach (var product in order.Products)
                 {
+                    var productElement = new XElement("product",new XAttribute("id",product.Id));
                     xml.Append("<product");
                     xml.Append(" id='");
                     xml.Append(product.Id);
                     xml.Append("'");
                     if (product.IsEvent())
                     {
+                        productElement.Add(new XAttribute("stylist", StylistFor(product)));
                         xml.Append(" stylist='");
                         xml.Append(StylistFor(product));
                         xml.Append("'");
@@ -32,12 +38,9 @@ namespace ProductExport
 
                     if (product.Weight > 0)
                     {
-                        xml.Append(" weight='");
-                        xml.Append(product.Weight);
-                        xml.Append("'");
+                        productElement.Add(new XAttribute("weight", product.Weight));
                     }
 
-                    xml.Append(">");
                     xml.Append("<price");
                     xml.Append(" currency='");
                     xml.Append(product.Price.CurrencyCode);
@@ -52,6 +55,7 @@ namespace ProductExport
             }
 
             xml.Append("</orders>");
+            var document = new XDocument(root);
             return XmlFormatter.PrettyPrint(xml.ToString());
         }
 

--- a/CSharp/ProductExport/XmlExporterTest.ExportFull.verified.xml
+++ b/CSharp/ProductExport/XmlExporterTest.ExportFull.verified.xml
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-16"?>
-<orders>
+﻿<orders>
   <order id="1234">
     <product id="EVENT02" stylist="Celeste Pulchritudo">
       <price currency="USD">149.99</price>Makeover</product>

--- a/CSharp/ProductExport/XmlExporterTest.cs
+++ b/CSharp/ProductExport/XmlExporterTest.cs
@@ -17,9 +17,13 @@ namespace ProductExport
         [Fact]
         public Task ExportFull()
         {
-            var orders = new List<Order>() {SampleModelObjects.RecentOrder, SampleModelObjects.OldOrder};
+            var orders = new List<Order>
+            {
+                SampleModelObjects.RecentOrder,
+                SampleModelObjects.OldOrder
+            };
             var xml = XmlExporter.ExportFull(orders);
-            return VerifyXml(xml);
+            return Verifier.Verify(xml);
         }
 
         private Task VerifyXml(string xml)


### PR DESCRIPTION
re this https://github.com/VerifyTests/Verify/issues/585

the reason Verify doesnt have a `VerifyXml` is that i assumed it was sufficient to have support for `XDocument`.

`XDocument` is the current recommended way to build up an xml string.

In this PR i changed `ExportFull` over to returning a `XDocument`. That can then be passed directly to `Verifier.Verify`.

side note Verify also has support for `XmlNode`, `XmlDocument`, and `XElement`.